### PR TITLE
Removing link for localhost:3000. No need for that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm start
 
 _([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
 
-Then open [http://localhost:3000/](http://localhost:3000/) to see your app.<br>
+Then open _`http://localhost:3000/`_ to see your app.<br>
 When you’re ready to deploy to production, create a minified bundle with `npm run build`.
 
 <p align='center'>


### PR DESCRIPTION
What I did to verify my changes was: 
1. I commited to my own fork
2. I checked README.md, and saw the thing I wanted to see: No link.
Screenshots included
<img width="1440" alt="Screen Shot 2020-10-24 at 20 03 46" src="https://user-images.githubusercontent.com/56798701/97087632-1fa5c480-1634-11eb-8ca7-0bd7e70a8319.png">
